### PR TITLE
escape for error page to allow apostrophes to be added

### DIFF
--- a/app/components/general/components/bc-error-page/macro.njk
+++ b/app/components/general/components/bc-error-page/macro.njk
@@ -8,7 +8,7 @@
         "text": params.backLink.text
       }) }}
     </div>
-    <h1 class="nhsuk-heading-l nhsuk-u-margin-top-5" data-test-id="error-title">{{ params.error.title }}</h1>
-    <p data-test-id="error-description">{{ params.error.description }}</p>
+    <h1 class="nhsuk-heading-l nhsuk-u-margin-top-5" data-test-id="error-title">{{ params.error.title | safe }}</h1>
+    <p data-test-id="error-description">{{ params.error.description | safe }}</p>
   </div>
 {% endmacro %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-components",
-  "version": "1.1.65",
+  "version": "1.1.70",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-components",
-  "version": "1.1.70",
+  "version": "1.1.71",
   "description": "Nodejs express app for Buying Catalogue components",
   "main": "./app/server.js",
   "scripts": {


### PR DESCRIPTION
The error page for no suppliers returned contains an `'` which then results in it being encoded on render. Had to add this to stop that from happening.

Story AB#4840
Task AB#7101