### PR TITLE
pass in flag to remove border-bottom

### DIFF
--- a/app/components/general/components/bc-table-flexible/macro.njk
+++ b/app/components/general/components/bc-table-flexible/macro.njk
@@ -25,7 +25,8 @@
     {% for row in params.data %}
       <tr data-test-id="table-row-{{ loop.index0 }}">
         {% for dataPoint in row %}
-          <td class="nhsuk-u-padding-bottom-0">
+          {% set borderBottom = "none" if (dataPoint.hideSeperator) else "solid" %}
+          <td class="nhsuk-u-padding-bottom-0" style="border-bottom-style: {{ borderBottom  }}">
 
             {% if dataPoint.href %}
               <a data-test-id="{{ dataPoint.dataTestId }}" href="{{ dataPoint.href }}">{{ dataPoint.data }}</a>

--- a/app/components/general/components/bc-table-flexible/macro.test.js
+++ b/app/components/general/components/bc-table-flexible/macro.test.js
@@ -133,6 +133,34 @@ describe('table', () => {
       });
     }));
 
+    it('should render the cell without a border bottom if the hideSeperator is provided', componentTester(setup, (harness) => {
+      const context = {
+        params: {
+          data: [
+            [{ hideSeperator: true }],
+          ],
+        },
+      };
+
+      harness.request(context, ($) => {
+        expect($('td').attr('style')).toEqual('border-bottom-style: none');
+      });
+    }));
+
+    it('should render the cell with a border bottom if the hideSeperator is not provided', componentTester(setup, (harness) => {
+      const context = {
+        params: {
+          data: [
+            [{}],
+          ],
+        },
+      };
+
+      harness.request(context, ($) => {
+        expect($('td').attr('style')).toEqual('border-bottom-style: solid');
+      });
+    }));
+
     it('should render the cell as a link if a href property is provided', componentTester(setup, (harness) => {
       const context = {
         params: {

--- a/app/components/general/components/bc-table-flexible/settings.json
+++ b/app/components/general/components/bc-table-flexible/settings.json
@@ -35,7 +35,8 @@
             "dataTestId": "view-section-some-section-id",
             "title": "ExpandableSection title 1",
             "innerComponent": "Some inner text (could be html)"
-          }
+          },
+          "hideSeperator": true
         },
         { "tag": { "dataTestId": "a-tag-id-1", "text": "tag text", "classes": "bc-c-tag-outline" } },
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-components",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "Nodejs express app for Buying Catalogue components",
   "main": "./app/server.js",
   "scripts": {


### PR DESCRIPTION
Story AB#5127
Task AB#8074

![Screenshot 2020-07-01 at 13 03 07](https://user-images.githubusercontent.com/9801518/86241674-42026680-bb9b-11ea-91df-3bb0069adadd.png)

sets the border-bottom-style on the cell to none if the hideSeperator flag is provided