### PR TITLE
Override button from nhsuk-frontend

### DIFF
--- a/app/components/general/components/bc-button/macro.njk
+++ b/app/components/general/components/bc-button/macro.njk
@@ -1,4 +1,4 @@
-{% from 'components/button/macro.njk' import button %}
+{% from './nhsuk-macro.njk' import button %}
 
 {% macro bcButton(params) %}
 
@@ -18,7 +18,8 @@
       classes: params.classes,
       href: params.href,
       disabled: disableButton,
-      attributes: params.attributes
+      attributes: params.attributes,
+      element: params.element
     }) }}
   </div>
 {% endmacro %}

--- a/app/components/general/components/bc-button/macro.test.js
+++ b/app/components/general/components/bc-button/macro.test.js
@@ -111,4 +111,31 @@ describe('bcButton', () => {
       expect($('div[data-test-id="some-button-identifier"] button').hasClass('nhsuk-button--disabled')).toEqual(true);
     });
   }));
+
+  it('should render a span with a href if the link is disabled', componentTester(setup, (harness) => {
+    const context = {
+      params: {
+        dataTestId: 'some-button-identifier',
+        href: '/some-href',
+        disabled: 'true',
+      },
+    };
+
+    harness.request(context, ($) => {
+      expect($('div[data-test-id="some-button-identifier"] span').attr('href')).toEqual('/some-href');
+    });
+  }));
+
+  it('should render a div if that element is supplied', componentTester(setup, (harness) => {
+    const context = {
+      params: {
+        dataTestId: 'some-button-identifier',
+        element: 'div',
+      },
+    };
+
+    harness.request(context, ($) => {
+      expect($('div[data-test-id="some-button-identifier"] div').length).toEqual(1);
+    });
+  }));
 });

--- a/app/components/general/components/bc-button/nhsuk-macro.njk
+++ b/app/components/general/components/bc-button/nhsuk-macro.njk
@@ -1,0 +1,3 @@
+{% macro button(params) %}
+  {%- include "./nhsuk-template.njk" -%}
+{% endmacro %}

--- a/app/components/general/components/bc-button/nhsuk-template.njk
+++ b/app/components/general/components/bc-button/nhsuk-template.njk
@@ -1,0 +1,40 @@
+{# Define type of element to use, if not explicitly set #}
+
+{% if params.element %}
+  {% set element = params.element | lower %}
+{% else %}
+  {% if params.href and params.disabled %}
+    {% set element = 'span' %}
+  {% elseif params.href %}
+    {% set element = 'a' %}
+  {% else %}
+    {% set element = 'button' %}
+  {% endif %}
+{% endif %}
+
+{# Define common attributes that we can use across all element types #}
+{% set commonAttributes %} class="nhsuk-button
+  {%- if params.classes %} {{ params.classes }}{% endif %}
+  {%- if params.disabled %} nhsuk-button--disabled{% endif %}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+{%- endset -%}
+
+{# Define common attributes we can use for both button and input types #}
+{%- set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"
+   {%- if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}
+ {%- endset -%}
+
+{% if element == 'button' %}
+<button{{ commonAttributes | safe }}{% if params.value %} value="{{ params.value }}"{% endif %}{{ buttonAttributes | safe }}>
+  {{ params.html | safe if params.html else params.text }}
+</button>
+
+{% elseif element == 'input' %}
+<input{{ commonAttributes | safe }} value="{{ params.text }}"{{ buttonAttributes | safe }}>
+
+{% else %}
+<{{element}}{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" draggable="false"{%- if params.disabled %} aria-disabled="true"{% endif %}>
+  {{ params.html | safe if params.html else params.text }}
+</{{element}}>
+
+{% endif %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-components",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-components",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Nodejs express app for Buying Catalogue components",
   "main": "./app/server.js",
   "scripts": {


### PR DESCRIPTION
Override button from nhsuk-frontend, disabled links are rendered as spans

[AB#11724](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/11724)

My solution is the most semantically correct, there is no way to actually disable a link as a disabled link is no longer a link technically speaking, it is just text. By removing the 'a' but leaving the 'href', it can easily be transformed back into a link by JS potentially.

An optimal solution would be making the page into a form but this brings with it certain behaviors which might not be desirable.

I have imported and re-written this component from 'nhsuk-frontend':
https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/button

If everyone is happy with this PR, I will create the same one against 'nhsuk-frontend' and we will have to add a task to remove this fix when we update the package.

For review, it would be worth comparing the files 'nhsuk-template.njk' against the 'template.njk' in the link provided. I have made the 'element' parameter a bit more flexible and added a test for it.
